### PR TITLE
Add SEA practice questions page

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,15 @@
 </div>
 
 
-  <!-- Page 6: Working In Progress -->
-  <div class="page" contenteditable="true">
-    <h1>Working In Progress</h1>
-    <div class="editable">
-      <!-- Click here and type your own content... -->
+  <!-- Page 6: SEA Practice Questions -->
+  <div class="page practice-page">
+    <h1>SEA Practice Questions</h1>
+    <div class="practice-container">
+      <div id="practice-question" class="practice-question"></div>
+      <input id="practice-answer" type="number" class="answer-input" placeholder="Answer">
+      <button id="practice-submit" class="submit-btn">Check Answer</button>
+      <button id="practice-new" class="submit-btn">Next Question</button>
+      <div id="practice-feedback" class="feedback"></div>
     </div>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -176,9 +176,56 @@ function setupDrag() {
       }
       it.draggable = false;
     });
-    document.getElementById("drag-feedback").textContent =
+  document.getElementById("drag-feedback").textContent =
       `${correct} correct, ${wrong} wrong`;
   });
+}
+
+// === Page 6: SEA Practice Questions ===
+function generatePracticeQuestion() {
+  const ops = ["+", "-", "×", "÷"];
+  const op = ops[randInt(3)];
+  let a, b, q, ans;
+  switch (op) {
+    case "+":
+      a = randInt(999); b = randInt(999);
+      q = `${a} + ${b}`; ans = a + b; break;
+    case "-":
+      a = randInt(999); b = randInt(a);
+      q = `${a} - ${b}`; ans = a - b; break;
+    case "×":
+      a = randInt(99); b = randInt(99);
+      q = `${a} × ${b}`; ans = a * b; break;
+    default: // division
+      b = randInt(12) + 1;
+      a = b * randInt(12);
+      q = `${a} ÷ ${b}`; ans = a / b; break;
+  }
+  return { q, ans };
+}
+
+function setupPractice() {
+  const qEl = document.getElementById("practice-question");
+  if (!qEl) return;
+  const ansEl = document.getElementById("practice-answer");
+  const fbEl = document.getElementById("practice-feedback");
+  let currentAns = 0;
+
+  function newQ() {
+    const { q, ans } = generatePracticeQuestion();
+    currentAns = ans;
+    qEl.textContent = q;
+    ansEl.value = "";
+    fbEl.textContent = "";
+  }
+
+  document.getElementById("practice-submit").addEventListener("click", () => {
+    const val = Number(ansEl.value);
+    fbEl.textContent = val === currentAns ? "Correct!" : `Incorrect. Answer: ${currentAns}`;
+  });
+  document.getElementById("practice-new").addEventListener("click", newQ);
+
+  newQ();
 }
 
 // === Initialize All ===
@@ -186,4 +233,5 @@ document.addEventListener("DOMContentLoaded", () => {
   populateBingo("bingo1");
   setupTreasure();
   setupDrag();
+  setupPractice();
 });

--- a/style.css
+++ b/style.css
@@ -202,3 +202,18 @@ ol.treasure-hunt li {
   cursor: grabbing;
   background-color: rgba(70, 70, 70, 0.8);
 }
+
+/* === SEA Practice Page === */
+.practice-container {
+  text-align: center;
+}
+
+.practice-question {
+  font-size: 28px;
+  margin-bottom: 10px;
+}
+
+.practice-page .answer-input {
+  width: 80px;
+  margin-right: 6px;
+}


### PR DESCRIPTION
## Summary
- add SEA practice questions page to index
- provide styles for practice questions
- implement question generation in script.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687525f92e9c832db1040145c0f85fb9